### PR TITLE
refactor/heading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ function App() {
   return (
     <div className="app">
       <header className="header">
-        <Heading locKey="main_heading" screenReaderOnly={true} />
+        <Heading locKey="main_heading" />
 
         <Logo href="https://www.linkedin.com/in/carlosechauri" />
       </header>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,17 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import './App.scss';
 
+import Heading from 'components/Heading/Heading';
 import Logo from 'components/Logo/Logo';
 import LanguageSwitcher from 'components/LanguageSwitcher/LanguageSwitcher';
 import SocialNetworks from 'components/SocialNetworks/SocialNetworks';
 import Description from 'components/Description/Description';
 
 function App() {
-  const { t } = useTranslation();
-
   return (
     <div className="app">
       <header className="header">
-        {/* @todo create heading component */}
-        <h1 className="screen-reader-only">{t('main_heading')}</h1>
+        <Heading locKey="main_heading" screenReaderOnly={true} />
 
         <Logo href="https://www.linkedin.com/in/carlosechauri" />
       </header>

--- a/src/components/Heading/Heading.scss
+++ b/src/components/Heading/Heading.scss
@@ -1,7 +1,5 @@
 @import 'scss/utility';
 
 .heading {
-  &--screen-reader-only {
-    @extend %screen-reader-only;
-  }
+  @extend %screen-reader-only;
 }

--- a/src/components/Heading/Heading.scss
+++ b/src/components/Heading/Heading.scss
@@ -1,0 +1,7 @@
+@import 'scss/utility';
+
+.heading {
+  &--screen-reader-only {
+    @extend %screen-reader-only;
+  }
+}

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { I18nTestWrapper } from 'test/utils';
+import { render } from '@testing-library/react';
+import Heading from './Heading';
+
+describe('Heading', () => {
+  const renderComponent = (locKey: string, screenReaderOnly = false) =>
+    render(
+      <I18nTestWrapper>
+        <Heading locKey={locKey} screenReaderOnly={screenReaderOnly} />
+      </I18nTestWrapper>
+    );
+
+  it('should render when valid locKey is set', () => {
+    const { getByText } = renderComponent('main_heading');
+    const heading = getByText(/charliechauri, software engineer/i);
+
+    expect(heading).toBeInTheDocument();
+    expect(heading.tagName).toBe('H1');
+  });
+
+  it("should render locKey when it's not valid", () => {
+    const { getByText } = renderComponent('invalid_loc_key');
+    const heading = getByText(/invalid_loc_key/i);
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('should render for screen reader only', () => {
+    const { getByText } = renderComponent('main_heading', true);
+    const heading = getByText(/charliechauri, software engineer/i);
+
+    expect(heading).toBeInTheDocument();
+    expect(heading.className).toBe('heading heading--screen-reader-only');
+  });
+});

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -4,10 +4,10 @@ import { render } from '@testing-library/react';
 import Heading from './Heading';
 
 describe('Heading', () => {
-  const renderComponent = (locKey: string, screenReaderOnly = false) =>
+  const renderComponent = (locKey: string) =>
     render(
       <I18nTestWrapper>
-        <Heading locKey={locKey} screenReaderOnly={screenReaderOnly} />
+        <Heading locKey={locKey} />
       </I18nTestWrapper>
     );
 
@@ -17,6 +17,7 @@ describe('Heading', () => {
 
     expect(heading).toBeInTheDocument();
     expect(heading.tagName).toBe('H1');
+    expect(heading.className).toBe('heading');
   });
 
   it("should render locKey when it's not valid", () => {
@@ -24,13 +25,5 @@ describe('Heading', () => {
     const heading = getByText(/invalid_loc_key/i);
 
     expect(heading).toBeInTheDocument();
-  });
-
-  it('should render for screen reader only', () => {
-    const { getByText } = renderComponent('main_heading', true);
-    const heading = getByText(/charliechauri, software engineer/i);
-
-    expect(heading).toBeInTheDocument();
-    expect(heading.className).toBe('heading heading--screen-reader-only');
   });
 });

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,0 +1,28 @@
+import React, { FunctionComponent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import './Heading.scss';
+
+export interface HeadingProps {
+  locKey: string;
+  screenReaderOnly?: boolean;
+}
+
+const Heading: FunctionComponent<HeadingProps> = ({
+  locKey,
+  screenReaderOnly = false,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <h1
+      className={`heading ${
+        screenReaderOnly ? 'heading--screen-reader-only' : ''
+      }`}
+    >
+      {t(locKey)}
+    </h1>
+  );
+};
+
+export default Heading;

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -5,24 +5,12 @@ import './Heading.scss';
 
 export interface HeadingProps {
   locKey: string;
-  screenReaderOnly?: boolean;
 }
 
-const Heading: FunctionComponent<HeadingProps> = ({
-  locKey,
-  screenReaderOnly = false,
-}) => {
+const Heading: FunctionComponent<HeadingProps> = ({ locKey }) => {
   const { t } = useTranslation();
 
-  return (
-    <h1
-      className={`heading ${
-        screenReaderOnly ? 'heading--screen-reader-only' : ''
-      }`}
-    >
-      {t(locKey)}
-    </h1>
-  );
+  return <h1 className="heading">{t(locKey)}</h1>;
 };
 
 export default Heading;

--- a/src/scss/_utility.scss
+++ b/src/scss/_utility.scss
@@ -1,4 +1,4 @@
-.screen-reader-only {
+%screen-reader-only {
   position: absolute;
   width: 1px;
   height: 1px;


### PR DESCRIPTION
# Refactoring Heading component

## 📖 Description/Context

refactor: update utility css class to be only extended
refactor: create Heading component

   -  Remove raw html from App component for heading use instead new Heading component
   - Heading default behavior to be visually hidden: for a11y purposes only one top level heading should be present in the page, due to current design it should be screen reader only

## Trello/Jira/Etc

Closes: #7 