### PR TITLE
refactor: replace FunctionComponent type with shorthand

### DIFF
--- a/src/components/Description/Description.tsx
+++ b/src/components/Description/Description.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent } from 'react';
+import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import './Description.scss';
 
 export interface DescriptionProps {}
 
-const Description: FunctionComponent<DescriptionProps> = () => {
+const Description: FC<DescriptionProps> = () => {
   const { t } = useTranslation();
 
   return (

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import './Heading.scss';
@@ -7,7 +7,7 @@ export interface HeadingProps {
   locKey: string;
 }
 
-const Heading: FunctionComponent<HeadingProps> = ({ locKey }) => {
+const Heading: FC<HeadingProps> = ({ locKey }) => {
   const { t } = useTranslation();
 
   return <h1 className="heading">{t(locKey)}</h1>;

--- a/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent } from 'react';
+import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import LOCALES from 'locales/locales';
 import Select from 'components/Select/Select';
 
 export interface LanguageSwitcherProps {}
 
-const LanguageSwitcher: FunctionComponent<LanguageSwitcherProps> = () => {
+const LanguageSwitcher: FC<LanguageSwitcherProps> = () => {
   const { t, i18n } = useTranslation();
   const { language } = i18n;
 

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import './Logo.scss';
@@ -8,7 +8,7 @@ export interface LogoProps {
   href: string;
 }
 
-const Logo: FunctionComponent<LogoProps> = ({ href }) => {
+const Logo: FC<LogoProps> = ({ href }) => {
   const { t } = useTranslation();
 
   return (

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, FormEvent, useState } from 'react';
+import React, { FC, FormEvent, useState } from 'react';
 
 import SelectOption, {
   SelectOptionProps as SelectOptionPropsDefinition,
@@ -14,7 +14,7 @@ export interface SelectProps {
   onChange?: (newValue: string) => void;
 }
 
-const Select: FunctionComponent<SelectProps> = ({
+const Select: FC<SelectProps> = ({
   className,
   initialValue,
   options,

--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -1,13 +1,12 @@
-import React, { FunctionComponent } from 'react';
+import React, { FC } from 'react';
 
 export interface SelectOptionProps {
   value: string;
   displayValue: string;
 }
 
-const SelectOption: FunctionComponent<SelectOptionProps> = ({
-  value,
-  displayValue,
-}) => <option value={value}>{displayValue}</option>;
+const SelectOption: FC<SelectOptionProps> = ({ value, displayValue }) => (
+  <option value={value}>{displayValue}</option>
+);
 
 export default SelectOption;

--- a/src/components/SocialNetworks/SocialNetworks.tsx
+++ b/src/components/SocialNetworks/SocialNetworks.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import './SocialNetworks.scss';
@@ -6,7 +6,7 @@ import { socialNetworks } from './list';
 
 export interface SocialNetworksProps {}
 
-const SocialNetworks: FunctionComponent<SocialNetworksProps> = () => {
+const SocialNetworks: FC<SocialNetworksProps> = () => {
   const { t } = useTranslation();
 
   return (

--- a/src/test/I18nTestWrapper.tsx
+++ b/src/test/I18nTestWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { ReactChild, FunctionComponent } from 'react';
+import React, { ReactChild, FC } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import i18n from 'i18n';
 
@@ -6,8 +6,8 @@ export interface I18nTestWrapperProps {
   children: ReactChild;
 }
 
-const I18nTestWrapper: FunctionComponent<I18nTestWrapperProps> = ({
-  children,
-}) => <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
+const I18nTestWrapper: FC<I18nTestWrapperProps> = ({ children }) => (
+  <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+);
 
 export default I18nTestWrapper;


### PR DESCRIPTION
# Use shorthand type for `FunctionComponent`

## 📖 Description/Context

--

## Trello/Jira/Etc

Fixes: #32 