### PR TITLE
refactor: rename component to improve readability

### DIFF
--- a/src/components/GlobalSelectors/GlobalSelectors.tsx
+++ b/src/components/GlobalSelectors/GlobalSelectors.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import LanguageSwitcher from 'components/LanguageSwitcher/LanguageSwitcher';
+import LanguageSelector from 'components/LanguageSelector/LanguageSelector';
 import ThemeSelector from 'components/ThemeSelector/ThemeSelector';
 
 import './GlobalSelectors.scss';
@@ -10,7 +10,7 @@ export interface GlobalSelectorsProps {}
 const GlobalSelectors: FC<GlobalSelectorsProps> = () => {
   return (
     <section className="global-selectors">
-      <LanguageSwitcher />
+      <LanguageSelector />
       <ThemeSelector />
     </section>
   );

--- a/src/components/LanguageSelector/LanguageSelector.test.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.test.tsx
@@ -1,28 +1,28 @@
 import React from 'react';
 import { I18nTestWrapper } from 'test/utils';
 import { render, fireEvent } from '@testing-library/react';
-import LanguageSwitcher from './LanguageSwitcher';
+import LanguageSelector from './LanguageSelector';
 
 describe('Heading', () => {
   const renderComponent = () =>
     render(
       <I18nTestWrapper>
-        <LanguageSwitcher />
+        <LanguageSelector />
       </I18nTestWrapper>
     );
 
   it('should render when valid locKey is set', async () => {
     const { getByLabelText, getByText } = renderComponent();
-    const languageSwitcher = getByLabelText(
+    const languageSelector = getByLabelText(
       /Select an option to change language/i
     ) as HTMLSelectElement;
     const defaultOption = getByText(/English/i);
 
     expect(defaultOption).toBeVisible();
-    expect(languageSwitcher).toBeInTheDocument();
-    expect(languageSwitcher.value).toBe('en');
+    expect(languageSelector).toBeInTheDocument();
+    expect(languageSelector.value).toBe('en');
 
-    fireEvent.change(languageSwitcher, { value: 'es' });
+    fireEvent.change(languageSelector, { value: 'es' });
 
     expect(getByText(/Español/i)).toBeVisible();
   });

--- a/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from 'react-i18next';
 import LOCALES from 'locales/locales';
 import Select from 'components/Select/Select';
 
-export interface LanguageSwitcherProps {}
+export interface LanguageSelectorProps {}
 
-const LanguageSwitcher: FC<LanguageSwitcherProps> = () => {
+const LanguageSelector: FC<LanguageSelectorProps> = () => {
   const { t, i18n } = useTranslation();
   const { language } = i18n;
 
@@ -29,4 +29,4 @@ const LanguageSwitcher: FC<LanguageSwitcherProps> = () => {
   );
 };
 
-export default LanguageSwitcher;
+export default LanguageSelector;


### PR DESCRIPTION
# Rename `<LanguageSwitcher>`

## 📖 Description/Context

Rename to `<LanguageSelector />` since switcher sounds more like it only supports a boolean value


## Trello/Jira/Etc

Fix: #40 