### PR TITLE
test: improve tests

### DIFF
--- a/src/components/LanguageSelector/LanguageSelector.test.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.test.tsx
@@ -22,8 +22,9 @@ describe('Heading', () => {
     expect(languageSelector).toBeInTheDocument();
     expect(languageSelector.value).toBe('en');
 
-    fireEvent.change(languageSelector, { value: 'es' });
+    fireEvent.change(languageSelector, { target: { value: 'es' } });
 
     expect(getByText(/Español/i)).toBeVisible();
+    expect(languageSelector.value).toBe('es');
   });
 });

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -34,18 +34,17 @@ describe('renders learn react link', () => {
     const firstOption = getByText('1st');
 
     expect(select).toBeInTheDocument();
+    expect(select.value).toBe('first');
     expect(firstOption).toBeInTheDocument();
 
-    fireEvent.change(select, { value: 'second' });
-
+    fireEvent.change(select, { target: { value: 'second' } });
     const secondOption = getByText('2nd');
-
     expect(secondOption).toBeInTheDocument();
+    expect(select.value).toBe('second');
 
-    fireEvent.change(select, { value: 'third' });
-
+    fireEvent.change(select, { target: { value: 'third' } });
     const thirdOption = getByText('3rd');
-
     expect(thirdOption).toBeInTheDocument();
+    expect(select.value).toBe('third');
   });
 });


### PR DESCRIPTION
# Improve tests in Select elements

## 📖 Description/Context

The API for `fireEvent.change` was not being used properly, in order to set an `option` in a `select` element via this function is with:

```ts
fireEvent.change(selectElement, { target: { value: 'desired_value' } })
```
## Trello/Jira/Etc

Fixes: #44