### PR TITLE
feat: error boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import ThemeContext, { Themes, Palette } from 'ThemeContext';
 import GlobalSelectors from 'components/GlobalSelectors/GlobalSelectors';
 import Loading from 'components/Loading/Loading';
-import ErrorBoundary from './ErrorBoundary';
+import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
 
 import './App.scss';
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import ThemeContext, { Themes, Palette } from 'ThemeContext';
 import GlobalSelectors from 'components/GlobalSelectors/GlobalSelectors';
 import Loading from 'components/Loading/Loading';
+import ErrorBoundary from './ErrorBoundary';
 
 import './App.scss';
 
@@ -24,17 +25,18 @@ function App() {
   return (
     <div className={`app app--${theme}`}>
       <ThemeContext.Provider value={{ theme, setTheme }}>
-        <Router>
-          <Suspense fallback={<Loading />}>
-            <Switch>
-              <Route exact path="/">
-                <Home />
-              </Route>
-            </Switch>
-          </Suspense>
-        </Router>
-
-        <GlobalSelectors />
+        <ErrorBoundary>
+          <Router>
+            <Suspense fallback={<Loading />}>
+              <Switch>
+                <Route exact path="/">
+                  <Home />
+                </Route>
+              </Switch>
+            </Suspense>
+          </Router>
+          <GlobalSelectors />
+        </ErrorBoundary>
       </ThemeContext.Provider>
     </div>
   );

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,7 +1,11 @@
 import React, { Component } from 'react';
-import Link, { TargetTypes } from 'components/Link/Link';
 
-export interface ErrorBoundaryProps {}
+import { withTranslation, WithTranslation } from 'react-i18next';
+
+import Link, { TargetTypes } from 'components/Link/Link';
+import Heading, { Levels } from 'components/Heading/Heading';
+
+export interface ErrorBoundaryProps extends WithTranslation {}
 
 export interface ErrorBoundaryState {
   hasError: boolean;
@@ -21,23 +25,27 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       return this.props.children;
     }
 
+    const { t } = this.props;
+    const emojiDescription = t('error_emoji_description');
+    const errorMessage = t('error_message');
+    const errorButtonMessage = t('error_button');
+
     return (
       <section>
-        <h1>Error</h1>
+        <Heading level={Levels.ONE} locKey="error_heading" />
+        <p>{errorMessage}</p>
         <p>
-          Something went wrong{' '}
-          <span role="img" aria-label="disappointed face">
+          <span role="img" aria-label={emojiDescription}>
             😕
           </span>
-          , please reload page
         </p>
 
         <Link href="#" target={TargetTypes.SELF}>
-          Reload!
+          {errorButtonMessage}
         </Link>
       </section>
     );
   }
 }
 
-export default ErrorBoundary;
+export default withTranslation()(ErrorBoundary);

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import React, { Component } from 'react';
+import Link, { TargetTypes } from 'components/Link/Link';
+
+export interface ErrorBoundaryProps {}
+
+export interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <section>
+        <h1>Error</h1>
+        <p>
+          Something went wrong{' '}
+          <span role="img" aria-label="disappointed face">
+            😕
+          </span>
+          , please reload page
+        </p>
+
+        <Link href="#" target={TargetTypes.SELF}>
+          Reload!
+        </Link>
+      </section>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable no-console */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { I18nTestWrapper } from 'test/utils';
+
+import ErrorBoundary from './ErrorBoundary';
+
+let consoleSpy: jest.SpyInstance<void, [any?, ...any[]]>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+beforeAll(() => {
+  consoleSpy = jest.spyOn(console, 'error');
+  consoleSpy.mockImplementation(() => {});
+});
+
+afterAll(() => {
+  consoleSpy.mockRestore();
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+function ThrowError({ shouldThrow = false }) {
+  if (shouldThrow) {
+    throw new Error('💣');
+  } else {
+    return null;
+  }
+}
+
+test('should render error state when error is thrown in children components', () => {
+  const { getByLabelText, getByText, rerender } = render(
+    <I18nTestWrapper>
+      <ErrorBoundary>
+        <ThrowError />
+      </ErrorBoundary>
+    </I18nTestWrapper>
+  );
+
+  rerender(
+    <I18nTestWrapper>
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    </I18nTestWrapper>
+  );
+
+  expect.any(Error);
+  expect(console.error).toHaveBeenCalledTimes(2);
+  getByText('Ooops');
+  getByText('Something went wrong, please reload the page');
+  getByLabelText('Dissapointed face');
+  getByText('Reload page');
+});

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -20,6 +20,10 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     };
   }
 
+  componentDidCatch() {
+    this.setState({ hasError: true });
+  }
+
   render() {
     if (!this.state.hasError) {
       return this.props.children;

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -21,7 +21,11 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   componentDidCatch() {
-    this.setState({ hasError: true });
+    // @todo Add logging
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
   }
 
   render() {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -8,6 +8,10 @@
     "theme_selector_label": "Select a theme",
     "theme_selector_light": "Light",
     "theme_selector_dark": "Dark",
-    "loading": "Loading"
+    "loading": "Loading",
+    "error_heading": "Ooops",
+    "error_message": "Something went wrong, please reload the page",
+    "error_emoji_description": "Dissapointed face",
+    "error_button": "Reload page"
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -8,6 +8,10 @@
     "theme_selector_label": "Selecciona un tema",
     "theme_selector_light": "Luminoso",
     "theme_selector_dark": "Oscuro",
-    "loading": "Cargando"
+    "loading": "Cargando",
+    "error_heading": "Ooops",
+    "error_message": "Algo salió mal, por favor recarga la página",
+    "error_emoji_description": "Carita de decepción",
+    "error_button": "Recargar página"
   }
 }


### PR DESCRIPTION
# Introduce `<ErrorBoundary />`

## 📖 Description/Context

- chore: add translations for error component
- test: add test coverage for <ErrorBoundary />
   - Following this example: https://github.com/kentcdodds/react-testing-library-course/blob/tjs/src/__tests__/error-boundary-03.js

Logged this issue to keep track of tech debt: #54



## Trello/Jira/Etc

Fixes: #51 

## Screenshots

<img width="326" alt="error_boundary" src="https://user-images.githubusercontent.com/11186658/84982224-daa8d900-b0fb-11ea-8c49-68faec9db0dd.png">


## 🧪 How to test

1. Modify whatever component inside `<App />`
1. Throw an error 
1. Start application: `yarn start`
1. Go to [homepage](http://localhost:3000)
1. The fallback UI for `<ErrorBoundary />` should be displayed
