### PR TITLE
Test/link

### DIFF
--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ThemeTestWrapper from 'test/ThemeTestWrapper';
+import Link, { TargetTypes } from './Link';
+
+describe('Link', () => {
+  it('should render, including default theme and custom css classes', () => {
+    const { getByText } = render(
+      <ThemeTestWrapper>
+        <Link href="#some-where" target={TargetTypes.BLANK} className="custom">
+          Regular link
+        </Link>
+      </ThemeTestWrapper>
+    );
+
+    const link = getByText('Regular link') as HTMLAnchorElement;
+
+    expect(link.className).toBe('link link--light custom');
+    expect(link.href).toContain('#some-where');
+    expect(link.rel).toBe('noopener noreferrer');
+    expect(link.target).toBe('_blank');
+  });
+});

--- a/src/test/ThemeTestWrapper.tsx
+++ b/src/test/ThemeTestWrapper.tsx
@@ -1,0 +1,24 @@
+import React, { ReactChild, FC } from 'react';
+import ThemeContext, { Themes } from 'ThemeContext';
+
+export interface ThemeTestWrapperProps {
+  children: ReactChild;
+  theme?: Themes;
+  setTheme?: (theme: Themes) => void;
+}
+
+const ThemeTestWrapper: FC<ThemeTestWrapperProps> = ({
+  children,
+  theme = Themes.LIGHT,
+  setTheme = () => {},
+}) => {
+  const themeProviderValue = { theme, setTheme };
+
+  return (
+    <ThemeContext.Provider value={themeProviderValue}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export default ThemeTestWrapper;


### PR DESCRIPTION
# Add missing coverage for component

## 📖 Description/Context

- Add new provider for testing components that use `ThemeContext`
- Add missing coverage for `<Link />`

## Trello/Jira/Etc

fixes: #42 