### PR TITLE
refactor: remove test utils package favoring a better naming convention

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { I18nTestWrapper } from 'test/utils';
+import { I18nProvider } from 'test/Providers';
 import { render, waitFor, fireEvent } from '@testing-library/react';
 import App from './App';
 
@@ -9,9 +9,9 @@ describe('App', () => {
   it('should render', async () => {
     const { getByAltText, getByLabelText, getByTestId, getByText } = render(
       <MemoryRouter initialEntries={['/']}>
-        <I18nTestWrapper>
+        <I18nProvider>
           <App />
-        </I18nTestWrapper>
+        </I18nProvider>
       </MemoryRouter>
     );
 

--- a/src/components/Description/Description.test.tsx
+++ b/src/components/Description/Description.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { I18nTestWrapper } from 'test/utils';
+import { I18nProvider } from 'test/Providers';
 import { render } from '@testing-library/react';
 import Description from './Description';
 
 describe('Description', () => {
   const renderComponent = () =>
     render(
-      <I18nTestWrapper>
+      <I18nProvider>
         <Description />
-      </I18nTestWrapper>
+      </I18nProvider>
     );
 
   it('should render', () => {

--- a/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import React from 'react';
 import { render } from '@testing-library/react';
-import { I18nTestWrapper } from 'test/utils';
+import { I18nProvider } from 'test/Providers';
 
 import ErrorBoundary from './ErrorBoundary';
 
@@ -30,19 +30,19 @@ function ThrowError({ shouldThrow = false }) {
 
 test('should render error state when error is thrown in children components', () => {
   const { getByLabelText, getByText, rerender } = render(
-    <I18nTestWrapper>
+    <I18nProvider>
       <ErrorBoundary>
         <ThrowError />
       </ErrorBoundary>
-    </I18nTestWrapper>
+    </I18nProvider>
   );
 
   rerender(
-    <I18nTestWrapper>
+    <I18nProvider>
       <ErrorBoundary>
         <ThrowError shouldThrow={true} />
       </ErrorBoundary>
-    </I18nTestWrapper>
+    </I18nProvider>
   );
 
   expect.any(Error);

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { I18nTestWrapper } from 'test/utils';
+import { I18nProvider } from 'test/Providers';
 import { render } from '@testing-library/react';
 import Heading, { Levels } from './Heading';
 
@@ -10,13 +10,13 @@ describe('Heading', () => {
     screenReaderOnly = false
   ) =>
     render(
-      <I18nTestWrapper>
+      <I18nProvider>
         <Heading
           level={level}
           locKey={locKey}
           screenReaderOnly={screenReaderOnly}
         />
-      </I18nTestWrapper>
+      </I18nProvider>
     );
 
   it('should render when valid locKey is set', () => {

--- a/src/components/LanguageSelector/LanguageSelector.test.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { I18nTestWrapper } from 'test/utils';
+import { I18nProvider } from 'test/Providers';
 import { render, fireEvent } from '@testing-library/react';
 import LanguageSelector from './LanguageSelector';
 
 describe('Heading', () => {
   const renderComponent = () =>
     render(
-      <I18nTestWrapper>
+      <I18nProvider>
         <LanguageSelector />
-      </I18nTestWrapper>
+      </I18nProvider>
     );
 
   it('should render when valid locKey is set', async () => {

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { ThemeTestWrapper } from 'test/utils';
+import { ThemeProvider } from 'test/Providers';
 import Link, { TargetTypes } from './Link';
 
 describe('Link', () => {
   it('should render, including default theme and custom css classes', () => {
     const { getByText } = render(
-      <ThemeTestWrapper>
+      <ThemeProvider>
         <Link href="#some-where" target={TargetTypes.BLANK} className="custom">
           Regular link
         </Link>
-      </ThemeTestWrapper>
+      </ThemeProvider>
     );
 
     const link = getByText('Regular link') as HTMLAnchorElement;

--- a/src/components/Loading/Loading.test.tsx
+++ b/src/components/Loading/Loading.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { I18nTestWrapper } from 'test/utils';
+import { I18nProvider } from 'test/Providers';
 import { render } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import Loading from './Loading';
@@ -9,9 +9,9 @@ describe('Loading', () => {
 
   const renderComponent = () =>
     render(
-      <I18nTestWrapper>
+      <I18nProvider>
         <Loading />
-      </I18nTestWrapper>
+      </I18nProvider>
     );
 
   it('should render', async () => {

--- a/src/components/Logo/Logo.test.tsx
+++ b/src/components/Logo/Logo.test.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { I18nTestWrapper } from 'test/utils';
+import { I18nProvider } from 'test/Providers';
 import { render } from '@testing-library/react';
 import Logo from './Logo';
 
 describe('Logo', () => {
   it('should render', () => {
     const { getByAltText } = render(
-      <I18nTestWrapper>
+      <I18nProvider>
         <Logo href="https://www.linkedin.com/in/carlosechauri" />
-      </I18nTestWrapper>
+      </I18nProvider>
     );
     const logo = getByAltText(/charliechauri's logo/i);
 

--- a/src/components/SocialNetworks/SocialNetworks.test.tsx
+++ b/src/components/SocialNetworks/SocialNetworks.test.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { I18nTestWrapper } from 'test/utils';
+import { I18nProvider } from 'test/Providers';
 
 import SocialNetworks from './SocialNetworks';
 
 describe('SocialNetworks', () => {
   const renderComponent = () =>
     render(
-      <I18nTestWrapper>
+      <I18nProvider>
         <SocialNetworks />
-      </I18nTestWrapper>
+      </I18nProvider>
     );
 
   it('should render title and list of social networks', () => {

--- a/src/components/ThemeSelector/ThemeSelector.test.tsx
+++ b/src/components/ThemeSelector/ThemeSelector.test.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
-import { ThemeTestWrapper, I18nTestWrapper } from 'test/utils';
+import { ThemeProvider, I18nProvider } from 'test/Providers';
 import ThemeSelector from './ThemeSelector';
 
 describe('ThemeSelector', () => {
   const renderComponent = () =>
     render(
-      <I18nTestWrapper>
-        <ThemeTestWrapper>
+      <I18nProvider>
+        <ThemeProvider>
           <ThemeSelector />
-        </ThemeTestWrapper>
-      </I18nTestWrapper>
+        </ThemeProvider>
+      </I18nProvider>
     );
 
   it('should render and change between available themes', () => {

--- a/src/test/Providers.tsx
+++ b/src/test/Providers.tsx
@@ -1,0 +1,4 @@
+import I18nProvider from 'test/providers/I18nProvider';
+import ThemeProvider from 'test/providers/ThemeProvider';
+
+export { I18nProvider, ThemeProvider };

--- a/src/test/providers/I18nProvider.tsx
+++ b/src/test/providers/I18nProvider.tsx
@@ -2,12 +2,12 @@ import React, { ReactChild, FC } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import i18n from 'i18n';
 
-export interface I18nTestWrapperProps {
+export interface I18nProviderProps {
   children: ReactChild;
 }
 
-const I18nTestWrapper: FC<I18nTestWrapperProps> = ({ children }) => (
+const I18nProvider: FC<I18nProviderProps> = ({ children }) => (
   <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
 );
 
-export default I18nTestWrapper;
+export default I18nProvider;

--- a/src/test/providers/ThemeProvider.tsx
+++ b/src/test/providers/ThemeProvider.tsx
@@ -1,13 +1,13 @@
 import React, { ReactChild, FC } from 'react';
 import ThemeContext, { Themes } from 'ThemeContext';
 
-export interface ThemeTestWrapperProps {
+export interface ThemeProviderProps {
   children: ReactChild;
   theme?: Themes;
   setTheme?: (theme: Themes) => void;
 }
 
-const ThemeTestWrapper: FC<ThemeTestWrapperProps> = ({
+const ThemeProvider: FC<ThemeProviderProps> = ({
   children,
   theme = Themes.LIGHT,
   setTheme = () => {},
@@ -21,4 +21,4 @@ const ThemeTestWrapper: FC<ThemeTestWrapperProps> = ({
   );
 };
 
-export default ThemeTestWrapper;
+export default ThemeProvider;

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,6 +1,0 @@
-import I18nTestWrapper from 'test/I18nTestWrapper';
-import ThemeTestWrapper from 'test/ThemeTestWrapper';
-
-export { I18nTestWrapper };
-
-export { ThemeTestWrapper };


### PR DESCRIPTION
# Remove `test/utils` by adding `test/Providers` module

## 📖 Description/Context

Currently the utils package included only `Providers` to be used in unit tests

Change name to providers package and components naming convention



## Trello/Jira/Etc

Fixes: #64 